### PR TITLE
Fixed compilation error when MOTOR_TEST is set to 1

### DIFF
--- a/firmware/mecanum_ps2/mecanum_ps2.ino
+++ b/firmware/mecanum_ps2/mecanum_ps2.ino
@@ -60,24 +60,32 @@ void setup() {
   // тест моторов
 #if (MOTOR_TEST == 1)
   Serial.println("front left");
-  motorFL.run(FORWARD, 100);
+  motorFL.setMode(AUTO);
+  motorFL.setSpeed(255);
   delay(3000);
-  motorFL.run(STOP);
+  motorFL.setSpeed(0);
+  motorFL.setMode(STOP);
   delay(1000);
   Serial.println("front right");
-  motorFR.run(FORWARD, 100);
+  motorFR.setMode(AUTO);
+  motorFR.setSpeed(255);
   delay(3000);
-  motorFR.run(STOP);
+  motorFR.setSpeed(0);
+  motorFR.setMode(STOP);
   delay(1000);
   Serial.println("back left");
-  motorBL.run(FORWARD, 100);
+  motorBL.setMode(AUTO);
+  motorBL.setSpeed(255);
   delay(3000);
-  motorBL.run(STOP);
+  motorBL.setSpeed(0);
+  motorBL.setMode(STOP);
   delay(1000);
   Serial.println("back right");
-  motorBR.run(FORWARD, 100);
+  motorBR.setMode(AUTO);
+  motorBR.setSpeed(255);
   delay(3000);
-  motorBR.run(STOP);
+  motorBR.setSpeed(0);
+  motorBR.setMode(STOP);
 #endif
   // минимальный сигнал на мотор
   motorFR.setMinDuty(30);

--- a/firmware/mecanum_ps2_opto/mecanum_ps2_opto.ino
+++ b/firmware/mecanum_ps2_opto/mecanum_ps2_opto.ino
@@ -86,24 +86,32 @@ void setup() {
   // тест моторов
 #if (MOTOR_TEST == 1)
   Serial.println("front left");
-  motorFL.run(FORWARD, 100);
+  motorFL.setMode(AUTO);
+  motorFL.setSpeed(255);
   delay(3000);
-  motorFL.run(STOP);
+  motorFL.setSpeed(0);
+  motorFL.setMode(STOP);
   delay(1000);
   Serial.println("front right");
-  motorFR.run(FORWARD, 100);
+  motorFR.setMode(AUTO);
+  motorFR.setSpeed(255);
   delay(3000);
-  motorFR.run(STOP);
+  motorFR.setSpeed(0);
+  motorFR.setMode(STOP);
   delay(1000);
   Serial.println("back left");
-  motorBL.run(FORWARD, 100);
+  motorBL.setMode(AUTO);
+  motorBL.setSpeed(255);
   delay(3000);
-  motorBL.run(STOP);
+  motorBL.setSpeed(0);
+  motorBL.setMode(STOP);
   delay(1000);
   Serial.println("back right");
-  motorBR.run(FORWARD, 100);
+  motorBR.setMode(AUTO);
+  motorBR.setSpeed(255);
   delay(3000);
-  motorBR.run(STOP);
+  motorBR.setSpeed(0);
+  motorBR.setMode(STOP);
 #endif
   // минимальный сигнал на мотор
   motorFR.setMinDuty(MIN_DUTY);


### PR DESCRIPTION
При попытке скомпилировать проект для запуска теста мотора (`#define MOTOR_TEST 1`) компилятор ругается потому что видимость метода run "protected": 

> mecanum_ps2_opto:89:27: error: 'void GMotor::run(workMode, int16_t)' is protected within this context

Если `MOTOR_TEST 0`, компилятор не компилирует код для тестирования моторчиков и ошибка не появляется.

Необходимо использовать "public" методы доступные в библиотеке GyverMotor. В коде заменены вызовы функции `run` на `setSpeed`. Выставляем режми движения `AUTO` для полного подчинения `setSpeed`, разгоняем моторчики, ждём, тормозим и переводим моторчики в режим STOP.
